### PR TITLE
2 New options - Dir ignore Prefix and Ignore Sort

### DIFF
--- a/bin/bundle-js.js
+++ b/bin/bundle-js.js
@@ -7,20 +7,20 @@ let options = {}
 options.dir = process.cwd()
 
 for (let i = 2; i < process.argv.length; ++i) {
-    if (process.argv[i].indexOf('--output ') == 0) {
-        options.dest = process.argv[i].split('--output ')[1]
-    } else if (process.argv[i].indexOf('--entry ') == 0) {
-        options.entry = process.argv[i].split('--entry ')[1]
-    } else if (process.argv[i].indexOf('--dir ') == 0) {
-        options.dir = process.argv[i].split('--dir ')[1]
-    } else if (process.argv[i].indexOf('--ignore-fileprefix ') == 0) {
-        options.dir_ignore_prefix = process.argv[i].split('--ignore-fileprefix ')[1]
-    } else if (process.argv[i].indexOf('--target ') == 0) {
-        options.target = process.argv[i].split('--target ')[1]
-    } else if (process.argv[i].indexOf('--exposed ') == 0) {
-        options.exposed = [process.argv[i].split('--exposed ')[1]]
-    } else if (process.argv[i].indexOf('--export ') == 0) {
-        options.export = process.argv[i].split('--export ')[1]
+    if (process.argv[i].indexOf('--output') == 0) {
+        options.dest = process.argv[i+1]
+    } else if (process.argv[i].indexOf('--entry') == 0) {
+        options.entry = process.argv[i+1]
+    } else if (process.argv[i].indexOf('--dir') == 0) {
+        options.dir = process.argv[i+1]
+    } else if (process.argv[i].indexOf('--ignore-fileprefix') == 0) {
+        options.dir_ignore_prefix = process.argv[i+1]
+    } else if (process.argv[i].indexOf('--target') == 0) {
+        options.target = process.argv[i+1]
+    } else if (process.argv[i].indexOf('--exposed') == 0) {
+        options.exposed = [process.argv[i+1]]
+    } else if (process.argv[i].indexOf('--export') == 0) {
+        options.export = process.argv[i+1]
     } else if (process.argv[i].indexOf('--ignore-sort') == 0) {
         options.ignore_sort = true
     } else if (process.argv[i].indexOf('--iife') == 0) {

--- a/bin/bundle-js.js
+++ b/bin/bundle-js.js
@@ -7,13 +7,14 @@ let options = {}
 options.dir = process.cwd()
 
 for (let i = 2; i < process.argv.length; ++i) {
+    // LEGACY PARAM
     if (process.argv[i].indexOf('o=') == 0 || process.argv[i].indexOf('out=') == 0 || process.argv[i].indexOf('dest=') == 0) {
         options.dest = process.argv[i].split('=')[1]
     } else if (process.argv[i].indexOf('entry=') == 0) {
         options.entry = process.argv[i].split('=')[1]
     } else if (process.argv[i].indexOf('dir=') == 0) {
         options.dir = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('dir-ignore-prefix=') == 0) {
+    } else if (process.argv[i].indexOf('ignore-fileprefix=') == 0) {
         options.dir_ignore_prefix = process.argv[i].split('=')[1]
     } else if (process.argv[i].indexOf('target=') == 0) {
         options.target = process.argv[i].split('=')[1]
@@ -21,6 +22,23 @@ for (let i = 2; i < process.argv.length; ++i) {
         options.exposed = [process.argv[i].split('=')[1]]
     } else if (process.argv[i].indexOf('export=') == 0) {
         options.export = process.argv[i].split('=')[1]
+    }
+    
+    
+    if (process.argv[i].indexOf('--output ') == 0) {
+        options.dest = process.argv[i].split('--output ')[1]
+    } else if (process.argv[i].indexOf('--entry ') == 0) {
+        options.entry = process.argv[i].split('--entry ')[1]
+    } else if (process.argv[i].indexOf('--dir ') == 0) {
+        options.dir = process.argv[i].split('--dir ')[1]
+    } else if (process.argv[i].indexOf('--ignore-fileprefix ') == 0) {
+        options.dir_ignore_prefix = process.argv[i].split('--ignore-fileprefix ')[1]
+    } else if (process.argv[i].indexOf('--target ') == 0) {
+        options.target = process.argv[i].split('--target ')[1]
+    } else if (process.argv[i].indexOf('--exposed ') == 0) {
+        options.exposed = [process.argv[i].split('--exposed ')[1]]
+    } else if (process.argv[i].indexOf('--export ') == 0) {
+        options.export = process.argv[i].split('--export ')[1]
     } else if (process.argv[i].indexOf('--ignore-sort') == 0) {
         options.ignore_sort = true
     } else if (process.argv[i].indexOf('--iife') == 0) {

--- a/bin/bundle-js.js
+++ b/bin/bundle-js.js
@@ -13,6 +13,8 @@ for (let i = 2; i < process.argv.length; ++i) {
         options.entry = process.argv[i].split('=')[1]
     } else if (process.argv[i].indexOf('dir=') == 0) {
         options.dir = process.argv[i].split('=')[1]
+    } else if (process.argv[i].indexOf('dir-ignore-prefix=') == 0) {
+        options.dir_ignore_prefix = process.argv[i].split('=')[1]
     } else if (process.argv[i].indexOf('target=') == 0) {
         options.target = process.argv[i].split('=')[1]
     } else if (process.argv[i].indexOf('exposed=') == 0) {

--- a/bin/bundle-js.js
+++ b/bin/bundle-js.js
@@ -7,24 +7,6 @@ let options = {}
 options.dir = process.cwd()
 
 for (let i = 2; i < process.argv.length; ++i) {
-    // LEGACY PARAM
-    if (process.argv[i].indexOf('o=') == 0 || process.argv[i].indexOf('out=') == 0 || process.argv[i].indexOf('dest=') == 0) {
-        options.dest = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('entry=') == 0) {
-        options.entry = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('dir=') == 0) {
-        options.dir = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('ignore-fileprefix=') == 0) {
-        options.dir_ignore_prefix = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('target=') == 0) {
-        options.target = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('exposed=') == 0) {
-        options.exposed = [process.argv[i].split('=')[1]]
-    } else if (process.argv[i].indexOf('export=') == 0) {
-        options.export = process.argv[i].split('=')[1]
-    }
-    
-    
     if (process.argv[i].indexOf('--output ') == 0) {
         options.dest = process.argv[i].split('--output ')[1]
     } else if (process.argv[i].indexOf('--entry ') == 0) {
@@ -43,6 +25,23 @@ for (let i = 2; i < process.argv.length; ++i) {
         options.ignore_sort = true
     } else if (process.argv[i].indexOf('--iife') == 0) {
         options.iife = true
+    }
+    
+    // LEGACY PARAM
+    else if (process.argv[i].indexOf('o=') == 0 || process.argv[i].indexOf('out=') == 0 || process.argv[i].indexOf('dest=') == 0) {
+        options.dest = process.argv[i].split('=')[1]
+    } else if (process.argv[i].indexOf('entry=') == 0) {
+        options.entry = process.argv[i].split('=')[1]
+    } else if (process.argv[i].indexOf('dir=') == 0) {
+        options.dir = process.argv[i].split('=')[1]
+    } else if (process.argv[i].indexOf('ignore-fileprefix=') == 0) {
+        options.dir_ignore_prefix = process.argv[i].split('=')[1]
+    } else if (process.argv[i].indexOf('target=') == 0) {
+        options.target = process.argv[i].split('=')[1]
+    } else if (process.argv[i].indexOf('exposed=') == 0) {
+        options.exposed = [process.argv[i].split('=')[1]]
+    } else if (process.argv[i].indexOf('export=') == 0) {
+        options.export = process.argv[i].split('=')[1]
     }
 }
 

--- a/bin/bundle-js.js
+++ b/bin/bundle-js.js
@@ -21,6 +21,8 @@ for (let i = 2; i < process.argv.length; ++i) {
         options.exposed = [process.argv[i].split('=')[1]]
     } else if (process.argv[i].indexOf('export=') == 0) {
         options.export = process.argv[i].split('=')[1]
+    } else if (process.argv[i].indexOf('--ignore-sort') == 0) {
+        options.ignore_sort = true
     } else if (process.argv[i].indexOf('--iife') == 0) {
         options.iife = true
     }

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function bundle(options = {}) {
         let fileList = []
         fileUtils.walkSync(normalizeDirPath(base, options.dir), function(dirPath, dirs, files) {
             for (let i = 0; i < files.length; ++i) {
-                if (files[i].endsWith('.js'))
+                if (files[i].endsWith('.js') && (!options.dir_ignore_prefix || !files[i].startsWith(options.dir_ignore_prefix)))
                     fileList.push(normalizeFilePath(base, pathUtils.resolve(base, dirPath, files[i])))
             }
         })

--- a/index.js
+++ b/index.js
@@ -105,9 +105,13 @@ class FileGraph {
 
 
 
-function getConcatOrderFromFileList(absPaths) {
+function getConcatOrderFromFileList(absPaths, sort) {
     let fileGraph = new FileGraph(...absPaths)
-    return toposort.array(fileGraph.getAsArray(), fileGraph.generateEdges()).reverse()
+    
+    if (sort)
+        return toposort.array(fileGraph.getAsArray(), fileGraph.generateEdges()).reverse()
+    else
+        return fileGraph.getAsArray()
 }
 
 /******************************************************************************/
@@ -115,17 +119,18 @@ function getConcatOrderFromFileList(absPaths) {
 function bundle(options = {}) {
 
     let base = options.dir || pathUtils.resolve(pathUtils.dirname(callerPath()))
+    let sort = (options.ignore_sort ? false : true)
 
     let concatOrder = []
 
     if (options.entry) {
-        concatOrder = getConcatOrderFromFileList( [ normalizeFilePath(base, options.entry) ] )
+        concatOrder = getConcatOrderFromFileList( [ normalizeFilePath(base, options.entry) ], sort )
     } else if (options.files) {
         let fileList = []
         for (let i = 0; i < options.files.length; ++i) {
             fileList.push(normalizeFilePath(base, options.files[i]))
         }
-        concatOrder = getConcatOrderFromFileList(fileList)
+        concatOrder = getConcatOrderFromFileList(fileList, sort)
     } else if (options.dir) {
         let fileList = []
         fileUtils.walkSync(normalizeDirPath(base, options.dir), function(dirPath, dirs, files) {
@@ -134,7 +139,7 @@ function bundle(options = {}) {
                     fileList.push(normalizeFilePath(base, pathUtils.resolve(base, dirPath, files[i])))
             }
         })
-        concatOrder = getConcatOrderFromFileList(fileList)
+        concatOrder = getConcatOrderFromFileList(fileList, sort)
     }
 
 


### PR DESCRIPTION
Option Dir ignore Prefix :
to be able to use, for example, the prefix "_" in included files.

Option ignore sort :
to be able to manually set the include order