### PR TITLE
Update to version 1.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Gábor Siffel
+Copyright (c) 2017 Gábor Siffel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bin/bundle-js.js
+++ b/bin/bundle-js.js
@@ -1,27 +1,31 @@
 #!/usr/bin/env node
 
-const bundle = require('../index.js')
+const optimist = require('optimist')
 
-let options = {}
+const globals = require('../globals.js')
 
-options.dir = process.cwd()
+let argv = optimist
+    .demand(1)
+    .options('o', { alias : ['out', 'dest'], default: globals.DEFAULT_OUTPUT_FILE, describe: 'Output file' })
+    .options('p', { boolean: true, alias : ['print'], describe: 'Print the final bundled output to stdout' })
+    .options('disable-beautify', { boolean: true, describe: 'Leave the concatenated files as-is (might be ugly!)' })
+    .usage(
+        '\n' +
+        'Usage: bundle-js ./path/to/entryfile.js [-o ./path/to/outputfile] [-p]\n' +     // 80 character line width limit here
+        '       [--disable-beautify]'
+    )
+    .argv
 
-for (let i = 2; i < process.argv.length; ++i) {
-    if (process.argv[i].indexOf('o=') == 0 || process.argv[i].indexOf('out=') == 0 || process.argv[i].indexOf('dest=') == 0) {
-        options.dest = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('entry=') == 0) {
-        options.entry = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('dir=') == 0) {
-        options.dir = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('target=') == 0) {
-        options.target = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('exposed=') == 0) {
-        options.exposed = [process.argv[i].split('=')[1]]
-    } else if (process.argv[i].indexOf('export=') == 0) {
-        options.export = process.argv[i].split('=')[1]
-    } else if (process.argv[i].indexOf('--iife') == 0) {
-        options.iife = true
-    }
+if (argv._[0] == 'help') {
+    optimist.showHelp()
+    process.exit()
 }
 
+let options = {}
+options.entryfilepath = argv._[0]
+options.destfilepath = argv.o
+options.print = argv.p
+options.disablebeautify = argv['disable-beautify']
+
+const bundle = require('../index.js')
 bundle(options)

--- a/bundler.js
+++ b/bundler.js
@@ -1,0 +1,178 @@
+const fs = require('fs')
+const path = require('path')
+const resolve = require('resolve')
+const beautify = require('js-beautify').js_beautify
+
+
+const ENCODING = 'utf-8'
+
+function REQUIRE_REGEX() {
+    return new RegExp(/\/\/+\s*REQUIRE\s+([^\s\n]+)/, "gi")
+}
+function INCLUDE_REGEX() {
+    return new RegExp(/\/\/+\s*INCLUDE\s+([^\s\n]+)/, "gi")
+}
+function INCLUDEB_REGEX() {
+    return new RegExp(/\/\/+\s*INCLUDE_?B\s+([^\s\n]+)/, "gi")
+}
+
+
+function concatFiles(files) {
+    let concatenated = ''
+
+    for (let file of files) {
+        concatenated += file.getFinalContent()
+        concatenated += '\n\n'
+    }
+
+    return concatenated
+}
+
+class File {
+    constructor(filepath, basedir = process.cwd()) {
+        this.absolutefilepath = File.resolve(filepath, basedir)
+        this.dependentfiles = []
+
+        this._generated = false
+
+        this.tempmark = false
+        this.permmark = false
+
+        this._contentwithincludes = null
+    }
+
+    readFile() {
+        return fs.readFileSync(this.absolutefilepath, 'utf-8')
+    }
+
+    getContentWithIncludes(existingfiles = [], ancestorincludes = []) {
+        if (this._contentwithincludes != null) {
+            return this._contentwithincludes
+        }
+
+        // Check for cyclical inclusions
+        ancestorincludes.forEach((file) => {
+            if (this.absolutefilepath == file.absolutefilepath) {
+                throw new Error('Ran into cyclical inclusion! Cannot INCLUDE file within itself: ' + this.absolutefilepath)
+            }
+        })
+
+        // Return contents with INCLUDE statements replaced with the inclusions
+        this._contentwithincludes = this.readFile().replace(INCLUDE_REGEX(), (m, p) => {
+            let includedfile = this.getRelativeFile(p, existingfiles)
+            return includedfile.getContentWithIncludes(existingfiles, ancestorincludes.concat([this]))
+        })
+        this._contentwithincludes = this.readFile().replace(INCLUDEB_REGEX(), (m, p) => {
+            let includedfile = this.getRelativeFile(p)
+            return bundle(includedfile.absolutefilepath, { disablebeautify: true })
+        })
+        return this._contentwithincludes
+    }
+
+    getFinalContent() {
+        if (this._contentwithincludes == null) {
+            throw new Error('An unknown error occured (_contentwithincludes was null)')
+        }
+
+        return this._contentwithincludes.replace(REQUIRE_REGEX(), () => '')
+    }
+
+    addDependentFile(file) {
+        for (let dependentfile of this.dependentfiles) {
+            if (file.absolutefilepath == dependentfile.absolutefilepath) {
+                return
+            }
+        }
+        this.dependentfiles.push(file)
+        this._generated = false
+    }
+
+    generateDependentFiles(existingfiles = []) {
+        if (this._generated == true) {
+            return
+        }
+
+        this.dependentfiles = []
+
+        let regex = REQUIRE_REGEX()
+
+        let matches
+        while (matches = regex.exec(this.getContentWithIncludes(existingfiles))) {
+            this.addDependentFile(this.getRelativeFile(matches[1], existingfiles))
+        }
+        this._generated = true
+    }
+
+    getRelativeFile(filepath, existingfiles = []) {
+        let newfile = new File(filepath, this.dir())
+        for (let existingfile of existingfiles) {
+            if (newfile.absolutefilepath == existingfile.absolutefilepath) {
+                return existingfile
+            }
+        }
+        existingfiles.push(newfile)
+        return newfile
+    }
+
+    dir() {
+        return path.dirname(this.absolutefilepath)
+    }
+
+    static resolve(filepath, basedir = process.cwd()) {
+        return path.normalize(
+            path.resolve(
+                resolve.sync(filepath, { basedir })
+            )
+        )
+    }
+}
+
+function toposortDependencies(entryfilepath) {
+    let existingfiles = []
+
+    let sortedlist = []
+
+    function DFSToposort(root) {
+        if (root.permmark)
+            return
+        if (root.tempmark)
+            throw new Error('Found a dependency cycle')
+
+        root.tempmark = true
+
+        // Generate dependencies on-the-fly while doing DFS
+        root.generateDependentFiles(existingfiles)
+
+        root.dependentfiles.forEach((vertex) => DFSToposort(vertex))
+
+        root.permmark = true
+
+        sortedlist.push(root)
+    }
+
+    let root = new File(entryfilepath)
+    existingfiles.push(root)
+    DFSToposort(root)
+
+    return sortedlist
+}
+
+
+function bundle(entryfilepath, options = {}) {
+
+    let order = toposortDependencies(entryfilepath)
+
+    let bundled = concatFiles(order)
+
+    if (!(options.disablebeautify == true)) {
+        bundled = beautify(bundled, {
+            indent_size: 4,
+            end_with_newline: true,
+            preserve_newlines: false
+        })
+    }
+
+    return bundled
+}
+
+module.exports = { bundle: bundle }

--- a/globals.js
+++ b/globals.js
@@ -1,0 +1,4 @@
+
+module.exports = {
+    DEFAULT_OUTPUT_FILE: './bundlejs/output.js'
+}

--- a/index.js
+++ b/index.js
@@ -1,199 +1,38 @@
-
 const fs = require('fs')
-const pathUtils = require('path')
-const callerPath = require('caller-path')
+const path = require('path')
 
-const fileUtils = require('file')
-
-const toposort = require('toposort')
-
-const beautify = require('js-beautify').js_beautify
-
-/******************************************************************************/
-
-let require_regex = /\/\/\s*require\s+(.+?)$/gm
-
-/******************************************************************************/
-
-function normalizeFilePath(base, path) {
-    return pathUtils.normalize(pathUtils.resolve(base, path))
-}
-
-function normalizeDirPath(base, path) {
-    return normalizeFilePath(base, path) + '/'
-}
-
-
-
-let getFileContent = function(absPath) {
-    return fs.readFileSync(absPath, "utf-8")
-}
-
-
-
-function getDirectDependencies(absFilePath, sourceCode) {
-    let deps = []
-
-    let base = normalizeDirPath(pathUtils.dirname(absFilePath), '')
-
-    require_regex.lastIndex = 0 // reset for .exec()
-    let matches
-    while (matches = require_regex.exec(sourceCode)) {
-        let relFilePath = matches[1]
-        if (!relFilePath.endsWith('.js')) relFilePath += '.js'
-        deps.push(normalizeFilePath(base, relFilePath))
-    }
-
-    return deps
-}
-
-
-
-class FileGraph {
-
-    constructor(...absPaths) {
-        this.list = {}
-        this.addWithAllDependencies(...absPaths)
-    }
-
-    addWithAllDependencies(...absPaths) {
-        let nodes = []
-        for (let i = 0; i < absPaths.length; ++i) {
-            let absPath = absPaths[i]
-            if (!this.list[absPath]) {
-                let content = getFileContent(absPath)
-                this.list[absPath] = {
-                    absPath : absPath,
-                    content : content
-                }
-                this.list[absPath].deps = this.addWithAllDependencies(...getDirectDependencies(absPath, content))
-            }
-            nodes.push(this.list[absPath])
-        }
-        return nodes
-    }
-
-    getAsArray() {
-        let arr = []
-
-        for (var path in this.list) {
-            if (!this.list.hasOwnProperty(path)) continue
-
-            arr.push(this.list[path])
-        }
-
-        return arr
-    }
-
-    generateEdges() {
-        let edges = []
-
-        for (var path in this.list) {
-            if (!this.list.hasOwnProperty(path)) continue
-
-            let file = this.list[path]
-
-            for (let i = 0; i < file.deps.length; ++i) {
-                edges.push( [file, file.deps[i]] )
-            }
-        }
-
-        return edges
-    }
-
-}
-
-
-
-function getConcatOrderFromFileList(absPaths) {
-    let fileGraph = new FileGraph(...absPaths)
-    return toposort.array(fileGraph.getAsArray(), fileGraph.generateEdges()).reverse()
-}
-
-/******************************************************************************/
+const globals = require('./globals.js')
+const bundler = require('./bundler.js')
 
 function bundle(options = {}) {
 
-    let base = options.dir || pathUtils.resolve(pathUtils.dirname(callerPath()))
-
-    let concatOrder = []
-
-    if (options.entry) {
-        concatOrder = getConcatOrderFromFileList( [ normalizeFilePath(base, options.entry) ] )
-    } else if (options.files) {
-        let fileList = []
-        for (let i = 0; i < options.files.length; ++i) {
-            fileList.push(normalizeFilePath(base, options.files[i]))
-        }
-        concatOrder = getConcatOrderFromFileList(fileList)
-    } else if (options.dir) {
-        let fileList = []
-        fileUtils.walkSync(normalizeDirPath(base, options.dir), function(dirPath, dirs, files) {
-            for (let i = 0; i < files.length; ++i) {
-                if (files[i].endsWith('.js'))
-                    fileList.push(normalizeFilePath(base, pathUtils.resolve(base, dirPath, files[i])))
-            }
-        })
-        concatOrder = getConcatOrderFromFileList(fileList)
+    if (!options.entry) {
+        throw new Error('options.entryfilepath was not defined')
     }
 
-
-    let concatenatedSource = ''
-
-    for (let i = 0; i < concatOrder.length; ++i) {
-        concatenatedSource += concatOrder[i].content.replace(require_regex, '')
-    }
-
-    if (options.target && options.target == 'module') {
-        // BUNDLE AS COMMONJS MODULE
-
-        if (options.export) {
-            concatenatedSource += '\nmodule.exports = ' + options.export + ';'
-        } else if (options.exposed) {
-            concatenatedSource += '\nmodule.exports = {'
-            for (let i = 0; i < options.exposed.length; ++i) {
-                if (i != 0) concatenatedSource += ','
-                concatenatedSource += options.exposed[i] + ':' + options.exposed[i]
-            }
-            concatenatedSource += '}'
-        }
-        if (options.iife)
-            concatenatedSource = '(function(){' + concatenatedSource + '})();'
-
-    } else if (options.target && options.target == 'browser') {
-        // BUNDLE FOR BROWSER
-
-        if (options.exposed) {
-            for (let i = 0; i < options.exposed.length; ++i) {
-                concatenatedSource += '\nwindow.' + options.exposed[i] + ' = ' + options.exposed[i] + ';'
-            }
-        } else if (options.export) {
-            concatenatedSource += '\nwindow.' + options.export + ' = ' + options.export + ';'
-        }
-        if (options.iife == undefined || options.iife)
-            concatenatedSource = '(function(){' + concatenatedSource + '})();'
-
-    } else if (options.export) {
-        concatenatedSource += '\nreturn ' + options.export + ';'
-        concatenatedSource = 'var ' + options.export + ' = (function(){' + concatenatedSource + '})();'
-    } else if (options.iife) {
-        concatenatedSource = '(function(){' + concatenatedSource + '})();'
-    }
-
-    concatenatedSource = beautify(concatenatedSource, { indent_size: 4 })
+    let entryfilepath = path.normalize(path.resolve(process.cwd(), options.entry))
+    let bundled = bundler.bundle(entryfilepath, options)
 
     if (options.dest) {
-        let dest = normalizeFilePath(base, options.dest)
-        if (!fs.existsSync(pathUtils.dirname(dest)))
-            fs.mkdirSync(pathUtils.dirname(dest))
-        fs.writeFileSync(dest, concatenatedSource, { encoding: "utf-8" })
+        let dest = path.normalize(path.resolve(process.cwd(), options.dest || globals.DEFAULT_OUTPUT_FILE))
+        if (!fs.existsSync(path.dirname(dest))) {
+            fs.mkdirSync(path.dirname(dest))
+        }
+        fs.writeFileSync(dest, bundled, { encoding: options.encoding || 'utf-8' })
+    }
+    if (options.print) {
+        process.stdout.write(bundled)
     } else {
-        process.stdout.write(concatenatedSource)
+        console.log('Bundled:', bundled.split('\n'), 'lines')
+        if (options.dest) {
+            console.log('Wrote to file:', options.dest)
+        }
+        console.log('Done.')
     }
 
-    return concatenatedSource
+    return bundled
 }
 
-/******************************************************************************/
-
 module.exports = bundle
+
+bundle({ entry: 'testWrapper.js', print: true} )

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bundle-js",
-  "version": "0.1.1",
-  "description": "Bundle your JavaScript projects for either the browser or Node.js",
+  "version": "1.0.0",
+  "description": "Bundle your JavaScript files",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -20,7 +20,9 @@
     "concatenate",
     "rollup",
     "roll",
-    "up"
+    "up",
+    "require",
+    "include"
   ],
   "author": "hugabor",
   "license": "MIT",
@@ -32,9 +34,8 @@
     "node": ">=6.8.1"
   },
   "dependencies": {
-    "caller-path": "^2.0.0",
-    "file": "^0.2.2",
     "js-beautify": "^1.6.4",
-    "toposort": "^1.0.0"
+    "optimist": "^0.6.1",
+    "resolve": "^1.4.0"
   }
 }


### PR DESCRIPTION
Rewrote most of the code.

As a result of the new way of modeling dependencies, it is now required to specify a single entry point. (Ie. you are no longer able to specify a directory and have all of the js files within be bundled.)
(Might want to re-add this feature.)

Switched to a new way of parsing command-line arguments.

These changes are not backwards compatible with previous versions.
Hopefully, from now on, backwards compatibility can be more easily kept.
