### PR TITLE
Use tabs instead of spaces for beautify configuration

### DIFF
--- a/bundler.js
+++ b/bundler.js
@@ -166,7 +166,7 @@ function bundle(entryfilepath, options = {}) {
 
     if (!(options.disablebeautify == true)) {
         bundled = beautify(bundled, {
-            indent_size: 4,
+            indent_with_tabs: true,
             end_with_newline: true,
             preserve_newlines: false
         })
@@ -174,5 +174,5 @@ function bundle(entryfilepath, options = {}) {
 
     return bundled
 }
-
+/
 module.exports = { bundle: bundle }


### PR DESCRIPTION
This could save around 20% of bandwidth for sending the bundled files: https://madskristensen.net/blog/performance-of-tabs-vs-spaces-in-html-files/

Doesn't enforce a tab width

Won't break any deployments